### PR TITLE
ADDED score progression and fixed button events bug

### DIFF
--- a/Assets/_Project/Develop/StunGames/GameJam29/Runtime/Gameplay/GameplayFlow.cs
+++ b/Assets/_Project/Develop/StunGames/GameJam29/Runtime/Gameplay/GameplayFlow.cs
@@ -42,6 +42,13 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime.Gameplay
 
         public async void RestartGame()
         {
+            _matchController.IsFirstMatch = true;
+            StartGame();
+        }
+
+        public async void StartNextlevel()
+        {
+            _matchController.IsFirstMatch = false;
             StartGame();
         }
 

--- a/Assets/_Project/Develop/StunGames/GameJam29/Runtime/MatchController.cs
+++ b/Assets/_Project/Develop/StunGames/GameJam29/Runtime/MatchController.cs
@@ -17,6 +17,7 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime
         private int _currentHealth;
         private bool _playerHasCard;
         private bool _isInputActive;
+        private bool _isFirstMatch;
         private Room _previousRoom;
         private Room _currentRoom;
         private Monster _monster;
@@ -25,6 +26,12 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime
         public int CurrentHealth => _currentHealth;
 
         public bool PlayerHasCard => _playerHasCard;
+
+        public bool IsFirstMatch
+        {
+            get => _isFirstMatch;
+            set => _isFirstMatch = value;
+        }
 
         public List<Room> Rooms => _rooms;
 
@@ -79,6 +86,7 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime
             Subscribe();
             _monster = new Monster(this,_rooms,_gameConfig);
             _monster.Initialize();
+            _isFirstMatch = true;
         }
 
 
@@ -128,7 +136,13 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime
 
         private void PlacePlayer()
         {
-            _currentHealth = _gameConfig.godMode? 999 :_gameConfig.StartHp;
+            // TODO: удалить если читаемость на тернарных операциях устраивает
+            // if (_gameConfig.godMode) _currentHealth = 999;
+            // if (_isFirstMatch) _currentHealth = _gameConfig.StartHp;
+            // else _currentHealth += _gameConfig.StartHp;
+            
+            _currentHealth = _gameConfig.godMode ? 999 : _isFirstMatch ? _gameConfig.StartHp : _currentHealth + _gameConfig.StartHp;
+            
             _currentPlayerView = _playerSpawner.SpawnPlayer();
             _currentPlayerView.SetHealth(_currentHealth);
             MovePlayer(_currentRoom);

--- a/Assets/_Project/Develop/StunGames/GameJam29/Runtime/UI/GameOverPopup.cs
+++ b/Assets/_Project/Develop/StunGames/GameJam29/Runtime/UI/GameOverPopup.cs
@@ -24,5 +24,11 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime.UI
             exitBtn.onClick.AddListener(_gameplayFlow.GameOver);
             exitBtn.onClick.AddListener(Hide);
         }
+
+        protected override void RemoveAllListeners()
+        {
+            restartBtn.onClick.RemoveAllListeners();
+            exitBtn.onClick.RemoveAllListeners();
+        }
     }
 }

--- a/Assets/_Project/Develop/StunGames/GameJam29/Runtime/UI/LevelCompletedPopup.cs
+++ b/Assets/_Project/Develop/StunGames/GameJam29/Runtime/UI/LevelCompletedPopup.cs
@@ -19,10 +19,16 @@ namespace _Project.Develop.StunGames.GameJam29.Runtime.UI
 
         protected override void BindButtons()
         {
-            restartBtn.onClick.AddListener(_gameplayFlow.RestartGame);
+            restartBtn.onClick.AddListener(_gameplayFlow.StartNextlevel);
             restartBtn.onClick.AddListener(Hide);
             exitBtn.onClick.AddListener(_gameplayFlow.GameOver);
             exitBtn.onClick.AddListener(Hide);
+        }
+
+        protected override void RemoveAllListeners()
+        {
+            restartBtn.onClick.RemoveAllListeners();
+            exitBtn.onClick.RemoveAllListeners();
         }
     }
 }


### PR DESCRIPTION
Добавил прибавление оставшихся хпшек на новый уровень при победе. При необходимости легко заменить bool переменную на int и отслеживать текущий уровень где-нибудь на HUD'е

В процессе нашёл и пофиксил баг с наслоениями событий (а точнее их невыгрузкой) на кнопках попапов.

Ну и да, там сейчас два варианта для одного и того-же подсчёта начальных хп. Один закоменченый и понятный, но громоздкий, а второй на длиннющей тернарной операции. Оставил для сравнения, ненужный можно будет удалить.